### PR TITLE
Add payment method name

### DIFF
--- a/includes/class-wc-gateway-swedbank-pay-checkout.php
+++ b/includes/class-wc-gateway-swedbank-pay-checkout.php
@@ -2446,7 +2446,7 @@ class WC_Gateway_Swedbank_Pay_Checkout extends WC_Payment_Gateway {
 	 * @return string
 	 */
 	public function payment_method_title( $value, $order ) {
-		if ( ! is_order_received_page() && ! is_account_page() ) {
+		if ( is_admin() ) {
 			return $value;
 		}
 


### PR DESCRIPTION
It appends Swedbank payments name to paymnet method title (configures in the WooCommerce settings) on every page except the admin backend