### PR TITLE
Add transaction link in WC admin

### DIFF
--- a/includes/class-wc-gateway-swedbank-pay-checkout.php
+++ b/includes/class-wc-gateway-swedbank-pay-checkout.php
@@ -989,6 +989,27 @@ class WC_Gateway_Swedbank_Pay_Checkout extends WC_Payment_Gateway {
 	}
 
 	/**
+	 * Get the transaction URL.
+	 *
+	 * @param  WC_Order $order Order object.
+	 * @return string
+	 */
+	public function get_transaction_url( $order ) {
+		$payment_order_id = $order->get_meta( '_payex_paymentorder_id' );
+		if ( empty( $payment_order_id ) ) {
+			return parent::get_transaction_url( $order );
+		}
+
+		if ( 'yes' === $this->testmode ) {
+			$view_transaction_url = 'https://admin.externalintegration.payex.com/psp/beta/paymentorders;id=%s';
+		} else {
+			$view_transaction_url = 'https://admin.externalintegration.payex.com/psp/beta/paymentorders;id=%s';
+		}
+
+		return sprintf( $view_transaction_url, urlencode( $payment_order_id ) );
+	}
+
+	/**
 	 * Process Payment
 	 *
 	 * @param int $order_id

--- a/tests/unit-tests/wc-gateway-swedbank-pay-checkout.php
+++ b/tests/unit-tests/wc-gateway-swedbank-pay-checkout.php
@@ -158,4 +158,20 @@ class WC_Unit_Gateway_Swedbank_Pay_Checkout extends WC_Unit_Test_Case {
 		$this->assertArrayHasKey( 'order_id', $result );
 		$this->assertArrayHasKey( 'line_items', $result );
 	}
+
+	public function test_get_transaction_url() {
+		/** @var WC_Order $order */
+		$order  = WC_Helper_Order::create_order();
+		$order->set_payment_method( $this->gateway );
+		$order->set_currency( 'SEK' );
+		$order->save();
+
+		// Save payment ID
+		$order->update_meta_data( '_payex_paymentorder_id', '/psp/test' );
+		$order->save_meta_data();
+
+		$result = $this->gateway->get_transaction_url( $order );
+
+		$this->assertContains('https', $result);
+	}
 }


### PR DESCRIPTION
Adds the link in order view of WC admin.
https://admin.externalintegration.payex.com/psp/beta/ or
https://admin.payex.com/psp/beta/
![ScreenshotZ1](https://user-images.githubusercontent.com/6286270/127811870-3d336695-8d41-403b-b9c7-56f2f91d990e.png)